### PR TITLE
ci: fix image version creation from tag

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -32,8 +32,8 @@ jobs:
           images: |
             ${{ env.IMAGE_NAME }}
           tags: |
-            # Only version, no revision
-            type=match,pattern=v(.*)-(.*),group=1
+            # Only version
+            type=match,pattern=v(.*),group=1
             # branch
             type=ref,event=branch
             # semver


### PR DESCRIPTION
This will match anything after `v` and make it the version.